### PR TITLE
Add palom as local module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -36,8 +36,20 @@ process {
         ]
     }
 
+    withName: ALIGNMULTIPLECYCLES {
+        ext.args = { params.palom_align_channel ? "--channel ${params.palom_align_channel}" : ''}
+        // TODO px_size specification?
+        ext.when = {params.registration_method.split(',').contains('palom')}
+        publishDir = [
+            path: { "${params.outdir}/registration/palom" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+
+
     withName: ASHLAR {
         containerOptions = '--user root'
+        ext.when = {params.registration_method.split(',').contains('ashlar')}
         publishDir = [
             path: { "${params.outdir}/registration/ashlar" },
             mode: params.publish_dir_mode,

--- a/modules/local/palom/alignmultiplecycles/environment.yml
+++ b/modules/local/palom/alignmultiplecycles/environment.yml
@@ -1,0 +1,11 @@
+name: "palom_multicycle"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "openslide=4.0.0"
+  - "scikit-image=0.19.3"
+  - pip
+  - pip:
+      - "palom==2024.4.1"

--- a/modules/local/palom/alignmultiplecycles/main.nf
+++ b/modules/local/palom/alignmultiplecycles/main.nf
@@ -1,0 +1,43 @@
+process ALIGNMULTIPLECYCLES {
+    tag "$meta.id"
+    label 'process_single'
+    container "docker.io/voigtgesa/palom:v2024.4.1_cli2"
+
+    input:
+    tuple val(meta), path(images, stageAs: 'image*/*')
+
+    output:
+    tuple val(meta), path("*.ome.tif"), emit: tif
+    path "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args          = task.ext.args           ?: ''
+    def prefix        = task.ext.prefix         ?: "${meta.id}"
+
+    """
+    python /palom/align_multiple_cycles.py \\
+        --img_list $images \\
+        --out_name ${prefix}.ome.tif \\
+        --out_dir . \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        palom: \$(palom-svs --version | sed 's/palom v//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.ome.tif
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        palom: \$(palom-svs --version | sed 's/palom v//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/palom/alignmultiplecycles/meta.yml
+++ b/modules/local/palom/alignmultiplecycles/meta.yml
@@ -1,0 +1,47 @@
+name: "palom_multiplecycles"
+description: Alignment for Multiple Layers of Mosaics
+keywords:
+  - image_processing
+  - registration
+  - alignment
+tools:
+  - "palom":
+      description: "Piecewise Alignment for Layers of Mosaics. Palom started as a tool for registering whole-slide images of the same FFPE section with different IHC stainings"
+      homepage: "https://github.com/labsyspharm/palom"
+      documentation: "https://github.com/labsyspharm/palom/blob/main/README.md"
+      tool_dev_url: "https://github.com/labsyspharm/palom"
+      doi: ""
+      licence: "" ## TODO Wait for licence specification (opened issue)
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+  - images:
+      type: path
+      description: List of paths to OME-TIF files, ordered by consecutive imaging cycles
+      pattern: "*.{ome.tiff,ome.tif,tif,tiff}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1']`
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - tif:
+      type: file
+      description: Registered image
+      pattern: "*.ome.tif"
+
+authors:
+  - "@kbestak"
+  - "@gesavoigt"
+maintainers:
+  - "@kbestak"
+  - "@gesavoigt"

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,8 @@ params {
     marker_sheet               = null
     segmentation               = 'mesmer'
     cellpose_model             = []
+    registration_method        = 'ashlar'
+    palom_align_channel        = 0
 
     // Illumination correction
     illumination               = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -69,11 +69,24 @@
                 "segmentation": {
                     "type": "string",
                     "pattern": "^((cellpose|mesmer)?,?)*(?<!,)$",
-                    "description": "comma separated list of segmentation modules to run. options are ['mesmer','cellpose']"
+                    "description": "comma separated list of segmentation modules to run. options are ['mesmer','cellpose']",
+                    "default": "mesmer"
                 },
                 "cellpose_model": {
                     "type": "string",
-                    "description": "optional model file for cellpose segmentation"
+                    "description": "optional model file for cellpose segmentation",
+                    "default": "[]"
+                },
+                "registration_method": {
+                    "type": "string",
+                    "default": "ashlar",
+                    "pattern": "^((ashlar|palom)?,?)*(?<!,)$",
+                    "description": "Registration method to be used (ashlar or palom)"
+                },
+                "palom_align_channel": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Channel to use for image registration"
                 }
             }
         },


### PR DESCRIPTION
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mcmicro _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Note: test & debug runs included default segmentation option ashlar, not palom

## Description of module specifications

For mcmicro, palom can be used to register pre-stitched images instead of ashlar.

The module as implemented here calls the script [`align_multiple_cycles.py`](https://github.com/SchapiroLabor/palom/blob/multichannel_tif_cli/palom/cli/align_multiple_cycles.py). The script is currently not integrated in the original palom repository, but a PR is opened by @kbestak. After it has been accepted, the next steps would be to update the pip package, create a new docker, and create an nf-core module (with the function being called through the package).

Note also that no license has been provided in the palom GitHub repo. An MIT license it expected to be added, an issue has been opened.

## Description of changes
- `nextflow.config`:
   - added pipeline param `registration_method` to choose between ashlar (default) and palom
   - added module param `palom_align_channel` to specify channel to use for image registration with palom
- `nextflow_schema.json`:
   - Reflects changes made to `nextflow.config`
- `conf/modules.config`:
   - based on `params.registration_method`, ashlar or palom can be executed
   - `param.palom_align_channel` is an optional parameter to specify the imaging channel used for alignment
- `workflows/mcmicro.nf`:
   - modify `ch_registration` for compatibility with both ashlar and palom
   - for palom, `ch_registration` combines all files with the same meta id to be registered into one image
- `modules/local/palom/alignmultiplecycles/`:
   - Implementation of the module as described above.