### PR TITLE
Avoid publishing versions.yml with module outputs

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -41,6 +41,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/registration/ashlar" },
             mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
@@ -51,6 +52,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/segmentation/deepcell_mesmer" },
             mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
@@ -59,6 +61,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/segmentation/cellpose" },
             mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
@@ -66,6 +69,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/quantification/mcquant/${meta2.segmenter}" },
             mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
@@ -74,6 +78,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/tma_dearray" },
             mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
 
     }


### PR DESCRIPTION
This adds the boilerplate publishDir saveAs configuration missing from most modules' config. Fixes #52 .

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mcmicro _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
