### PR TITLE
when file not found in DEEPCELL_MESMER test, the test is not run, so the issue isn't reported

### DIFF
--- a/modules/nf-core/deepcell/mesmer/tests/main.nf.test
+++ b/modules/nf-core/deepcell/mesmer/tests/main.nf.test
@@ -17,7 +17,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id: 'test_img' ],
-                    file(params.modules_testdata_base_path + '/modules/data/imaging/segmentation/cycif_tonsil_registered.ome.tif', checkIfExists: true)
+                    file(params.modules_testdata_base_path + '/modules/data/imaging/segmentation/cycif_tonsil_registered.ome.tif')
                 ]
                 input[1] = [
                     [:],


### PR DESCRIPTION
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).

I've changed to the tonsil file we usually use and new it's giving a new error, so looking into that as well.

So to be clear, there seem to be 2 issues.
1) If the file is not found the test is not run.
2) error generated from the file when found.