### PR TITLE
Improve backsub input validation and testing

### DIFF
--- a/assets/schema_input_cycle.json
+++ b/assets/schema_input_cycle.json
@@ -10,15 +10,18 @@
             "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "sample name must be provided and cannot contain spaces"
+                "errorMessage": "sample name must be provided and cannot contain spaces",
+                "meta": "id"
             },
             "cycle_number": {
                 "type": "integer",
-                "errorMessage": "cycle_number must be provided. It should be 1-based, sequential and have no gaps"
+                "errorMessage": "cycle_number must be provided. It should be 1-based, sequential and have no gaps",
+                "meta": "cycle_number"
             },
             "channel_count": {
                 "type": "integer",
-                "errorMessage": "channel_count name must be provided. It should be 1-based, sequential and have no gaps"
+                "errorMessage": "channel_count name must be provided. It should be 1-based, sequential and have no gaps",
+                "meta": "channel_count"
             },
             "image_tiles": {
                 "type": "string",

--- a/assets/schema_input_sample.json
+++ b/assets/schema_input_sample.json
@@ -10,7 +10,8 @@
             "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "Sample name must be provided and cannot contain spaces"
+                "errorMessage": "Sample name must be provided and cannot contain spaces",
+                "meta": "id"
             },
             "image_directory": {
                 "type": "string",

--- a/assets/schema_marker.json
+++ b/assets/schema_marker.json
@@ -54,6 +54,7 @@
             "background": {
                 "type": "string",
                 "default": null,
+                "pattern": "\\S",
                 "meta": "background"
             },
             "remove": {

--- a/assets/schema_marker.json
+++ b/assets/schema_marker.json
@@ -10,41 +10,56 @@
             "channel_number": {
                 "type": "integer",
                 "minimum": 1,
-                "errorMessage": "channel_number must be provided"
+                "errorMessage": "channel_number must be provided",
+                "meta": "channel_number"
             },
             "cycle_number": {
                 "type": "integer",
                 "minimum": 1,
-                "errorMessage": "cycle_number must be provided"
+                "errorMessage": "cycle_number must be provided",
+                "meta": "cycle_number"
             },
             "marker_name": {
                 "type": "string",
                 "pattern": "\\S",
-                "errorMessage": "marker_name must be provided"
+                "errorMessage": "marker_name must be provided",
+                "meta": "marker_name"
             },
             "filter": {
                 "type": "string",
+                "default": null,
                 "pattern": "\\S",
-                "errorMessage": ""
+                "errorMessage": "",
+                "meta": "filter"
             },
             "excitation_wavelength": {
                 "type": "integer",
-                "errorMessage": ""
+                "default": null,
+                "errorMessage": "",
+                "meta": "excitation_wavelength"
             },
             "emission_wavelength": {
                 "type": "integer",
-                "errorMessage": ""
+                "default": null,
+                "errorMessage": "",
+                "meta": "emission_wavelength"
             },
             "exposure": {
                 "type": "number",
+                "default": null,
                 "minimum": 0.001,
-                "errorMessage": "Exposure time must be a positive number."
+                "errorMessage": "Exposure time must be a positive number.",
+                "meta": "exposure"
             },
             "background": {
-                "type": "string"
+                "type": "string",
+                "default": null,
+                "meta": "background"
             },
             "remove": {
-                "type": "boolean"
+                "type": "boolean",
+                "default": null,
+                "meta": "remove"
             }
         },
         "required": ["channel_number", "cycle_number", "marker_name"]

--- a/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
@@ -76,15 +76,6 @@ workflow PIPELINE_INITIALISATION {
     //
     if (input_cycle) {
         ch_samplesheet = Channel.fromList(samplesheetToList(params.input_cycle, "${projectDir}/assets/schema_input_cycle.json"))
-            .map{
-                sample, cycle_number, channel_count, image_tiles, dfp, ffp ->
-                [
-                    [id: sample, cycle_number: cycle_number, channel_count: channel_count],
-                    image_tiles,
-                    dfp,
-                    ffp
-                ]
-            }
             .dump(tag: 'ch_samplesheet (cycle)')
     } else if (input_sample) {
         ch_samplesheet = Channel.fromList(samplesheetToList(params.input_sample, "${projectDir}/assets/schema_input_sample.json"))
@@ -93,7 +84,8 @@ workflow PIPELINE_INITIALISATION {
     }
 
     ch_markersheet = Channel.fromList(samplesheetToList(params.marker_sheet, "${projectDir}/assets/schema_marker.json"))
-        .toList()
+        // Extract only the meta-maps since we mark all fields as meta.
+        .collect({ it[0] }, flat: false)
         .map{ validateInputMarkersheet(it) }
         .dump(tag: 'ch_markersheet')
 
@@ -192,24 +184,23 @@ def validateInputMarkersheet( markersheet_data ) {
     def cycle_number_list = []
 
     markersheet_data.each { row ->
-        def (channel_number, cycle_number, marker_name) = row
 
-        if (marker_name_list.contains(marker_name)) {
+        if (marker_name_list.contains(row.marker_name)) {
             error("Duplicate marker name found in marker sheet!")
         } else {
-            marker_name_list.add(marker_name)
+            marker_name_list.add(row.marker_name)
         }
 
-        if (channel_number_list && (channel_number != channel_number_list[-1] && channel_number != channel_number_list[-1] + 1)) {
+        if (channel_number_list && (row.channel_number != channel_number_list[-1] && row.channel_number != channel_number_list[-1] + 1)) {
             error("Channel_number cannot skip values and must be in order!")
         } else {
-            channel_number_list.add(channel_number)
+            channel_number_list.add(row.channel_number)
         }
 
-        if (cycle_number_list && (cycle_number != cycle_number_list[-1] && cycle_number != cycle_number_list[-1] + 1)) {
+        if (cycle_number_list && (row.cycle_number != cycle_number_list[-1] && row.cycle_number != cycle_number_list[-1] + 1)) {
             error("Cycle_number cannot skip values and must be in order!")
         } else {
-            cycle_number_list.add(cycle_number)
+            cycle_number_list.add(row.cycle_number)
         }
     }
 
@@ -221,9 +212,9 @@ def validateInputMarkersheet( markersheet_data ) {
     }
 
     // validate backsub columns if present
-    def exposure_list = markersheet_data.findResults{ _1, _2, _3, _4, _5, _6, exposure, _8, _9 -> exposure ?: null }
-    def background_list = markersheet_data.findResults{ _1, _2, _3, _4, _5, _6, _7, background, _9 -> background ?: null }
-    def remove_list = markersheet_data.findResults{ _1, _2, _3, _4, _5, _6, _7, _8, remove -> remove ?: null }
+    def exposure_list = markersheet_data.findResults{ it.exposure }
+    def background_list = markersheet_data.findResults{ it.background }
+    def remove_list = markersheet_data.findResults{ it.remove }
 
     if (!background_list && (exposure_list || remove_list)) {
         error("No values in background column, but values in either exposure or remove columns.  Must have background column values to perform background subtraction.")
@@ -248,7 +239,7 @@ def validateInputMarkersheet( markersheet_data ) {
 
 def validateInputSamplesheetMarkersheet ( samples, markers ) {
     def sample_cycles = samples.collect{ meta, image_tiles, dfp, ffp -> meta.cycle_number }
-    def marker_cycles = markers.collect{ channel_number, cycle_number, marker_name, _1, _2, _3, _4, _5, _6 -> cycle_number }
+    def marker_cycles = markers.collect{ meta -> meta.cycle_number }
 
     if (marker_cycles.unique(false) != sample_cycles.unique(false) ) {
         error("cycle_number values must match between sample and marker sheets")
@@ -269,7 +260,7 @@ def validateInputSamplesheetMarkersheet ( samples, markers ) {
 }
 
 def expandSampleRow( row ) {
-    def (sample, image_directory, dfp, ffp) = row
+    def (meta, image_directory, dfp, ffp) = row
     def files = []
 
     file(image_directory).eachFileRecurse (FileType.FILES) {
@@ -279,7 +270,7 @@ def expandSampleRow( row ) {
     }
 
     return files.withIndex(1).collect{ f, i ->
-        [[id: sample, cycle_number: i], f, dfp, ffp]
+        [meta + [cycle_number: i], f, dfp, ffp]
     }
 }
 //

--- a/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
@@ -186,19 +186,19 @@ def validateInputMarkersheet( markersheet_data ) {
     markersheet_data.each { row ->
 
         if (marker_name_list.contains(row.marker_name)) {
-            error("Duplicate marker name found in marker sheet!")
+            error("Please check input markersheet -> duplicate marker name '${row.marker_name}'")
         } else {
             marker_name_list.add(row.marker_name)
         }
 
         if (channel_number_list && (row.channel_number != channel_number_list[-1] && row.channel_number != channel_number_list[-1] + 1)) {
-            error("Channel_number cannot skip values and must be in order!")
+            error("Please check input markersheet -> channel_number is not consecutive for marker '${row.marker_name}'")
         } else {
             channel_number_list.add(row.channel_number)
         }
 
         if (cycle_number_list && (row.cycle_number != cycle_number_list[-1] && row.cycle_number != cycle_number_list[-1] + 1)) {
-            error("Cycle_number cannot skip values and must be in order!")
+            error("Please check input markersheet -> cycle_number is not consecutive for marker '${row.marker_name}'")
         } else {
             cycle_number_list.add(row.cycle_number)
         }
@@ -208,29 +208,32 @@ def validateInputMarkersheet( markersheet_data ) {
     def test_tuples = [channel_number_list, cycle_number_list].transpose()
     def dups = test_tuples.countBy{ it }.findAll{ _, count -> count > 1 }*.key
     if (dups) {
-        error("Duplicate [channel, cycle] pairs: ${dups}")
+        error("Please check input markersheet -> duplicate [channel, cycle] pairs: ${dups}")
     }
 
-    // validate backsub columns if present
-    def exposure_list = markersheet_data.findResults{ it.exposure }
-    def background_list = markersheet_data.findResults{ it.background }
-    def remove_list = markersheet_data.findResults{ it.remove }
-
-    if (!background_list && (exposure_list || remove_list)) {
-        error("No values in background column, but values in either exposure or remove columns.  Must have background column values to perform background subtraction.")
-    } else if (background_list) {
-        inter_list = marker_name_list.intersect(background_list)
-        if (inter_list.size() != background_list.size()) {
-            outliers_list = background_list - inter_list
-            error('background column values must exist in the marker_name column. The following background column values do not exist in the marker_name column: ' + outliers_list)
+    // Validate backsub data
+    if (!params.backsub) {
+        def backsub_columns = ['exposure', 'background', 'remove']
+        if (markersheet_data*.subMap(backsub_columns)*.collect{ c, v -> v != null}.flatten().any()) {
+            log.warn("One or more of the ${backsub_columns.join('/')} columns are present in the marker sheet, but params.backsub is set to false. Subtraction will NOT be performed unless params.backsub is set to true.")
         }
-
-        if (!exposure_list) {
-            error('You must have at least one value in the exposure column to perform background subtraction')
+    } else {
+        if (markersheet_data.findResult{ it.background } == null) {
+            error("Please check input markersheet -> Backsub is enabled, but no background channels have been defined so subtraction can't proceed. Either set params.backsub=false or specify how the channel subtraction should be performed.")
         }
-
-        if (!remove_list) {
-            error ('You must have at least one value in the remove column to perform background subtraction')
+        def markers_used_as_background = markersheet_data.findResults{ it.background }.toSet()
+        markersheet_data.each { row ->
+            if (row.background) {
+                if (!row.exposure) {
+                    error("Please check input markersheet -> Missing exposure value for marker: '${row.marker_name}'")
+                }
+                if (row.background !in marker_name_list) {
+                    error("Please check input markersheet -> Unknown background '${row.background}' for marker '${row.marker_name}' (background must be the name of another marker in this sheet).")
+                }
+            }
+            if (row.marker_name in markers_used_as_background && !row.exposure) {
+                error("Please check input markersheet -> Missing exposure value for marker used as background: '${row.marker_name}'")
+            }
         }
     }
 
@@ -249,7 +252,7 @@ def validateInputSamplesheetMarkersheet ( samples, markers ) {
 
     def channel_cycle_map = samples.collect{ meta, image_tiles, dfp, ffp -> [meta.id,meta.cycle_number] }.groupBy{ it[0] }
     channel_cycle_map.each { entry ->
-        last_val = -1
+        def last_val = -1
         entry.value.collect{ it[1] }.each{ curr_val ->
             if (last_val != -1 && (curr_val > (last_val + 1) || curr_val <= last_val)) {
                 error("cycle_number values must be increasing with no gaps")

--- a/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mcmicro_pipeline/main.nf
@@ -214,14 +214,14 @@ def validateInputMarkersheet( markersheet_data ) {
     // Validate backsub data
     if (!params.backsub) {
         def backsub_columns = ['exposure', 'background', 'remove']
-        if (markersheet_data*.subMap(backsub_columns)*.collect{ c, v -> v != null}.flatten().any()) {
+        if (markersheet_data*.subMap(backsub_columns)*.collect{ c, v -> v != null }.flatten().any()) {
             log.warn("One or more of the ${backsub_columns.join('/')} columns are present in the marker sheet, but params.backsub is set to false. Subtraction will NOT be performed unless params.backsub is set to true.")
         }
     } else {
-        if (markersheet_data.findResult{ it.background } == null) {
+        def markers_used_as_background = markersheet_data.findResults{ it.background }.toSet()
+        if (!markers_used_as_background) {
             error("Please check input markersheet -> Backsub is enabled, but no background channels have been defined so subtraction can't proceed. Either set params.backsub=false or specify how the channel subtraction should be performed.")
         }
-        def markers_used_as_background = markersheet_data.findResults{ it.background }.toSet()
         markersheet_data.each { row ->
             if (row.background) {
                 if (!row.exposure) {

--- a/subworkflows/local/utils_nfcore_mcmicro_pipeline/tests/validate.nf.test
+++ b/subworkflows/local/utils_nfcore_mcmicro_pipeline/tests/validate.nf.test
@@ -1,0 +1,111 @@
+nextflow_function {
+
+    name "Validation behavior for pipeline inputs"
+    script "../main.nf"
+
+    test("Error on backsub if background column is empty") {
+        function "validateInputMarkersheet"
+        when {
+            params {
+                backsub = true
+            }
+            function {
+                """
+                input[0] = [
+                    [marker_name:"M1", cycle_number:1, channel_number:1, exposure: 100],
+                    [marker_name:"M2", cycle_number:1, channel_number:2, remove: true],
+                ]
+                """
+            }
+        }
+        then {
+            assert function.failed
+            assert function.stdout*.contains("set params.backsub=false").any()
+        }
+    }
+
+    test("Warn if backsub false but columns are provided") {
+        function "validateInputMarkersheet"
+        when {
+            params {
+                backsub = false
+            }
+            function {
+                """
+                input[0] = [
+                    [marker_name:"M1", cycle_number:1, channel_number:1, exposure: 100],
+                    [marker_name:"M2", cycle_number:1, channel_number:2, remove: true],
+                ]
+                """
+            }
+        }
+        then {
+            assert function.success
+            // log.warn output can't be tested yet - https://github.com/askimed/nf-test/issues/271
+            //assert function.stdout*.contains("Subtraction will NOT be performed").any()
+        }
+    }
+
+    test("Error on backsub if background value not in marker_name") {
+        function "validateInputMarkersheet"
+        when {
+            params {
+                backsub = true
+            }
+            function {
+                """
+                input[0] = [
+                    [marker_name:"M1", cycle_number:1, channel_number:1, exposure:1, background: "M3"],
+                ]
+                """
+            }
+        }
+        then {
+            assert function.failed
+            assert function.stdout*.contains("Unknown background").any()
+        }
+    }
+
+    test("Error on backsub if exposure time missing for foreground channel") {
+        function "validateInputMarkersheet"
+        when {
+            params {
+                backsub = true
+            }
+            function {
+                """
+                input[0] = [
+                    [marker_name:"M1", cycle_number:1, channel_number:1, background:"M2"],
+                    [marker_name:"M2", cycle_number:1, channel_number:2, exposure:1],
+                ]
+                """
+            }
+        }
+        then {
+            assert function.failed
+            assert function.stdout*.contains("Missing exposure value for marker:").any()
+        }
+    }
+
+    test("Error on backsub if exposure time missing for background channel") {
+        function "validateInputMarkersheet"
+        when {
+            params {
+                backsub = true
+            }
+            function {
+                """
+                input[0] = [
+                    [marker_name:"M1", cycle_number:1, channel_number:1, exposure:1, background:"M2"],
+                    [marker_name:"M2", cycle_number:1, channel_number:2],
+                ]
+                """
+            }
+        }
+        then {
+            assert function.failed
+            assert function.stdout*.find("Missing exposure.*background:").any()
+        }
+    }
+
+}

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -24,10 +24,10 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
                         ],
                     )
                     """
@@ -68,10 +68,10 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
                         ],
                     )
                     """
@@ -113,10 +113,10 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
                         ],
                     )
                     """
@@ -167,18 +167,18 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
-                            [5,1,'DNA_7',[],[],[],[],[],[]],
-                            [6,1,'ELANE7',[],[],[],[],[],[]],
-                            [7,1,'CD577',[],[],[],[],[],[]],
-                            [8,1,'CD457',[],[],[],[],[],[]],
-                            [9,1,'DNA_8',[],[],[],[],[],[]],
-                            [10,1,'ELANE8',[],[],[],[],[],[]],
-                            [11,1,'CD578',[],[],[],[],[],[]],
-                            [12,1,'CD458',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA_7'],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'ELANE7'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'CD577'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'CD457'],
+                            [channel_number: 9, cycle_number: 3, marker_name: 'DNA_8'],
+                            [channel_number: 10, cycle_number: 3, marker_name: 'ELANE8'],
+                            [channel_number: 11, cycle_number: 3, marker_name: 'CD578'],
+                            [channel_number: 12, cycle_number: 3, marker_name: 'CD458'],
                         ],
                     )
                     """
@@ -235,14 +235,14 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
-                            [5,1,'DNA_7',[],[],[],[],[],[]],
-                            [6,1,'ELANE7',[],[],[],[],[],[]],
-                            [7,1,'CD577',[],[],[],[],[],[]],
-                            [8,1,'CD457',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA_7'],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'ELANE7'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'CD577'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'CD457'],
                         ],
                     )
                     """
@@ -302,14 +302,14 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
-                            [5,1,'DNA_7',[],[],[],[],[],[]],
-                            [6,1,'ELANE7',[],[],[],[],[],[]],
-                            [7,1,'CD577',[],[],[],[],[],[]],
-                            [8,1,'CD457',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA_7'],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'ELANE7'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'CD577'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'CD457'],
                         ],
                     )
                     """
@@ -368,18 +368,18 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
-                            [5,1,'DNA_7',[],[],[],[],[],[]],
-                            [6,1,'ELANE7',[],[],[],[],[],[]],
-                            [7,1,'CD577',[],[],[],[],[],[]],
-                            [8,1,'CD457',[],[],[],[],[],[]],
-                            [9,1,'DNA_8',[],[],[],[],[],[]],
-                            [10,1,'ELANE8',[],[],[],[],[],[]],
-                            [11,1,'CD578',[],[],[],[],[],[]],
-                            [12,1,'CD458',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA_7'],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'ELANE7'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'CD577'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'CD457'],
+                            [channel_number: 9, cycle_number: 3, marker_name: 'DNA_8'],
+                            [channel_number: 10, cycle_number: 3, marker_name: 'ELANE8'],
+                            [channel_number: 11, cycle_number: 3, marker_name: 'CD578'],
+                            [channel_number: 12, cycle_number: 3, marker_name: 'CD458'],
                         ],
                     )
                     """
@@ -443,14 +443,14 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
-                            [5,1,'DNA_7',[],[],[],[],[],[]],
-                            [6,1,'ELANE7',[],[],[],[],[],[]],
-                            [7,1,'CD577',[],[],[],[],[],[]],
-                            [8,1,'CD457',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA_7'],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'ELANE7'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'CD577'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'CD457'],
                         ],
                     )
                     """
@@ -498,10 +498,10 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
-                            [2,1,'ELANE',[],[],[],[],[],[]],
-                            [3,1,'CD57',[],[],[],[],[],[]],
-                            [4,1,'CD45',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'ELANE'],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD57'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45'],
                         ],
                     )
                     """
@@ -544,7 +544,7 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA_6',[],[],[],[],[],[]],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA_6'],
                         ],
                     )
                     """
@@ -590,14 +590,14 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [1,1,'DNA 1',[],[],[],100,[],[]],
-                            [2,1,'Na/K ATPase',[],[],[],100,[],[]],
-                            [3,1,'CD3',[],[],[],100,[],[]],
-                            [4,1,'CD45RO',[],[],[],100,[],[]],
-                            [5,2,'DNA 2',[],[],[],100,[],[]],
-                            [6,2,'Antigen Ki67',[],[],[],100,[],[]],
-                            [7,2,'Pan-cytokeratin',[],[],[],100,[],[]],
-                            [8,2,'Aortic smooth muscle actin',[],[],[],100,[],[]]
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA 1', exposure: 100],
+                            [channel_number: 2, cycle_number: 1, marker_name: 'Na/K ATPase', exposure: 100],
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD3', exposure: 100],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45RO', exposure: 100],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA 2', exposure: 100],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'Antigen Ki67', exposure: 100],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'Pan-cytokeratin', exposure: 100],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'Aortic smooth muscle actin', exposure: 100]
                         ],
                     )
                     """

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -590,14 +590,14 @@ nextflow_workflow {
                     )
                     input[1] = Channel.of(
                         [
-                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA 1', exposure: 100],
+                            [channel_number: 1, cycle_number: 1, marker_name: 'DNA 1'],
                             [channel_number: 2, cycle_number: 1, marker_name: 'Na/K ATPase', exposure: 100],
-                            [channel_number: 3, cycle_number: 1, marker_name: 'CD3', exposure: 100],
-                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45RO', exposure: 100],
-                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA 2', exposure: 100],
-                            [channel_number: 6, cycle_number: 2, marker_name: 'Antigen Ki67', exposure: 100],
-                            [channel_number: 7, cycle_number: 2, marker_name: 'Pan-cytokeratin', exposure: 100],
-                            [channel_number: 8, cycle_number: 2, marker_name: 'Aortic smooth muscle actin', exposure: 100]
+                            [channel_number: 3, cycle_number: 1, marker_name: 'CD3', exposure: 100, background: 'Na/K ATPase'],
+                            [channel_number: 4, cycle_number: 1, marker_name: 'CD45RO'],
+                            [channel_number: 5, cycle_number: 2, marker_name: 'DNA 2', remove: true],
+                            [channel_number: 6, cycle_number: 2, marker_name: 'Antigen Ki67'],
+                            [channel_number: 7, cycle_number: 2, marker_name: 'Pan-cytokeratin'],
+                            [channel_number: 8, cycle_number: 2, marker_name: 'Aortic smooth muscle actin']
                         ],
                     )
                     """

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -124,7 +124,6 @@
                     "Na/K ATPase",
                     "CD3",
                     "CD45RO",
-                    "DNA 2",
                     "Antigen Ki67",
                     "Pan-cytokeratin",
                     "Aortic smooth muscle actin",
@@ -140,11 +139,11 @@
                 ],
                 "rowCount": 2111
             },
-            "TEST1.backsub.ome.tif:md5,82b15c88057ab8fd8248402a687997ea"
+            "TEST1.backsub.ome.tif:md5,1be44fc5c0a60557bff3c2d0c69c2f41"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
         "timestamp": "2024-10-08T12:33:35.316668616"
     },

--- a/tests/workflows/mcmicro.nf.test
+++ b/tests/workflows/mcmicro.nf.test
@@ -22,10 +22,10 @@ nextflow_workflow {
                 )
                 input[1] = Channel.of(
                     [
-                        [1,1,'DNA 1',[],[],[],[],[],[]],
-                        [2,1,'Na/K ATPase',[],[],[],[],[],[]],
-                        [3,1,'CD3',[],[],[],[],[],[]],
-                        [4,1,'CD45RO',[],[],[],[],[],[]],
+                        [channel_number: 1, cycle_number: 1, marker_name: 'DNA 1'],
+                        [channel_number: 2, cycle_number: 1, marker_name: 'Na/K ATPase'],
+                        [channel_number: 3, cycle_number: 1, marker_name: 'CD3'],
+                        [channel_number: 4, cycle_number: 1, marker_name: 'CD45RO'],
                     ],
                 )
                 """

--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -77,10 +77,9 @@ workflow MCMICRO {
     if (params.backsub) {
         ch_backsub_markers = ch_markersheet
             .map { ['channel_number,cycle_number,marker_name,exposure,background,remove',
-                it.collect{ channel_number, cycle_number, marker_name, _1, _2, _3, exposure, background, remove ->
-                    channel_number + "," + cycle_number + "," + marker_name + "," + exposure + "," + background + "," + remove}] }
+                it.collect{ it.channel_number + "," + it.cycle_number + "," + it.marker_name + "," + it.exposure + "," + it.background + "," + it.remove}] }
             .flatten()
-            .map { it.replace('[]', '') }
+            .map { it.replaceAll('(?<=,|^)null(?=,|$)', '') }
             .collectFile(name: 'markers_backsub.csv', sort: false, newLine: true)
 
         ASHLAR.out.tif
@@ -137,7 +136,7 @@ workflow MCMICRO {
     ch_mcquant_markers = ch_markersheet
         .flatMap{
             ['marker_name'] +
-            it.collect{ _1, _2, marker_name, _4, _5, _6, _7, _8, _9 -> '"' + marker_name + '"' }
+            it.collect{ row -> '"' + row.marker_name + '"' }
         }
         .dump(tag: "MARKERS")
         .collectFile(name: 'markers.csv', sort: false, newLine: true)

--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -138,7 +138,7 @@ workflow MCMICRO {
         .concat(
             ch_markersheet
                 .flatten()
-                .filter{ row -> !row.remove }
+                .filter{ row -> !(params.backsub && row.remove) }
                 .map{ row -> '"' + row.marker_name + '"' }
         )
         .dump(tag: "MARKERS")

--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -132,12 +132,15 @@ workflow MCMICRO {
 
     // Run Quantification
 
-    // Generate markers.csv for mcquant with just the marker_name column.
-    ch_mcquant_markers = ch_markersheet
-        .flatMap{
-            ['marker_name'] +
-            it.collect{ row -> '"' + row.marker_name + '"' }
-        }
+    // Generate markers.csv for mcquant with just the marker_name column, and
+    // omitting rows removed by backsub.
+    ch_mcquant_markers = Channel.of('marker_name')
+        .concat(
+            ch_markersheet
+                .flatten()
+                .filter{ row -> !row.remove }
+                .map{ row -> '"' + row.marker_name + '"' }
+        )
         .dump(tag: "MARKERS")
         .collectFile(name: 'markers.csv', sort: false, newLine: true)
 


### PR DESCRIPTION
Rework of #82. Original features retained:
* Make `remove` column non-required.
* Don't allow backsub to run if no channels are linked to their respective background channels in the markersheet.
* Implement correct validation behavior for backsub-related markersheet columns. Error messages include marker_name or other identifying information to help the user find the problem more easily.
* Drop rows marked with `remove` from markersheet before generating input markersheet for quantification so that markersheet rows match up with image channels.
* Add tests for backsub input validation checks.
* Fix backsub test case in workflow test so it actually triggers backsub properly.

Updates relative to the original PR:
* Simplify markersheet handling by marking all fields in the schema as `meta` with a default value of `null`. Update all relevant places in the code and tests to use these maps instead of the old lists.
* Streamline error checking code branching structure in backsub input validation.
* Harmonize error messages with common nf-core practice and improved internal consistency.
* Port markersheet validation tests from workflow to function tests for easier input management (inputs can then be defined inline in the test script rather than requiring a discrete csv file).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
