### PR TITLE
Select large-disk CI runner

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - disk=large
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Increase CI disk space to help support large Docker containers.
