### PR TITLE
Make internal variables in local workflows local

### DIFF
--- a/modules/local/omevalidation/main.nf
+++ b/modules/local/omevalidation/main.nf
@@ -11,20 +11,20 @@ process OMEVALIDATION {
     tuple val(meta), val(sample_meta), val(marker_meta)
 
     exec:
-    xml = new XmlSlurper().parse(new File(xmlPath.toString()))
+    def xml = new XmlSlurper().parse(new File(xmlPath.toString()))
 
     /*
     SAMPLESHEET DATA ----------------------------------------------------------------------------------------------
     */
 
-    tile_count = xml.'**'.findAll { node -> node.name() == "Image"}.size()
+    def tile_count = xml.'**'.findAll { node -> node.name() == "Image"}.size()
 
     // TODO check if pre-stiched
     //if (tile_count < 2) {
     //   error 'Single image found in OMEXML metadata'
     //}
 
-    tile_size = xml.'**'.findAll {
+    def tile_size = xml.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@SizeX != '' && node.@SizeY != ''
         }
         .collect {
@@ -37,7 +37,7 @@ process OMEVALIDATION {
 
     tile_size = tile_size[0]
 
-    pixels = xml.'**'.findAll {
+    def pixels = xml.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@PhysicalSizeX != '' && node.@PhysicalSizeY != ''
         }
         .collect {
@@ -51,7 +51,7 @@ process OMEVALIDATION {
         error "Found non consistent pixels sizes in images."
     }
 
-    n_channels = xml.'**'.findAll {
+    def n_channels = xml.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@SizeC != ''
         }
         .collect { node -> node.@SizeC.toInteger() }
@@ -60,7 +60,7 @@ process OMEVALIDATION {
         error "Found inconsistent number of channels in images."
     }
 
-    size_units = xml.'**'.findAll {
+    def size_units = xml.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@PhysicalSizeXUnit != '' && node.@PhysicalSizeYUnit != ''
         }
         .collect { node -> [node.@PhysicalSizeXUnit.toString(), node.@PhysicalSizeYUnit.toString()] }
@@ -70,7 +70,7 @@ process OMEVALIDATION {
     }
 
     // transform pixel size to microns
-    s_units = size_units[0][0]
+    def s_units = size_units[0][0]
 
     if (s_units == 'mm'){
       pixels = pixels[0][0] / 1000
@@ -87,7 +87,7 @@ process OMEVALIDATION {
 
     pixels = pixels.round(3)
 
-    pixel_datatype = xml.'**'.findAll {
+    def pixel_datatype = xml.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@Type
         }
         .collect { node -> node.@Type.toString() }
@@ -104,7 +104,7 @@ process OMEVALIDATION {
     this needs to have channel specific data stored along so we can merge it reliably downstream
     */
 
-    exposure_time = xml.'**'.findAll {
+    def exposure_time = xml.'**'.findAll {
             node -> node.name() == 'Plane'
         }
         .collect {

--- a/modules/local/prelude/main.nf
+++ b/modules/local/prelude/main.nf
@@ -17,13 +17,13 @@ process SUMMARY_XML {
     def args        = task.ext.args ?: ''
     def prefix      = task.ext.prefix ?: "${meta.id}_${meta.cycle_number}"
 
-    check              = '\u2705'
-    cross              = '\u274C'
-    output_xml         = [["variable_name", "value", "expected", "check"]]
+    def check              = '\u2705'
+    def cross              = '\u274C'
+    def output_xml         = [["variable_name", "value", "expected", "check"]]
 
-    xml = new XmlSlurper().parse(new File(xml.toString()))
+    def xs = new XmlSlurper().parse(new File(xml.toString()))
 
-    tile_size = xml.'**'.findAll {
+    def tile_size = xs.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@SizeX != '' && node.@SizeY != ''
         }
         .collect {
@@ -41,7 +41,7 @@ process SUMMARY_XML {
         )
     }
 
-    pixels = xml.'**'.findAll {
+    def pixels = xs.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@PhysicalSizeX != '' && node.@PhysicalSizeY != ''
         }
         .collect {
@@ -60,7 +60,7 @@ process SUMMARY_XML {
         )
     }
 
-    n_channels = xml.'**'.findAll {
+    def n_channels = xs.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@SizeC != ''
         }
         .collect { node -> node.@SizeC.toInteger() }
@@ -76,7 +76,7 @@ process SUMMARY_XML {
         )
     }
 
-    size_units = xml.'**'.findAll {
+    def size_units = xs.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@PhysicalSizeXUnit != '' && node.@PhysicalSizeYUnit != ''
         }
         .collect { node -> [node.@PhysicalSizeXUnit.toString(), node.@PhysicalSizeYUnit.toString()] }
@@ -94,7 +94,7 @@ process SUMMARY_XML {
         )
     }
 
-    pixel_datatype = xml.'**'.findAll {
+    def pixel_datatype = xs.'**'.findAll {
             node -> node.name() == 'Pixels' && node.@Type
         }
         .collect { node -> node.@Type.toString() }
@@ -112,7 +112,7 @@ process SUMMARY_XML {
         )
     }
 
-    exposure_time = xml.'**'.findAll {
+    def exposure_time = xs.'**'.findAll {
             node -> node.name() == 'Plane'
         }
         .collect {
@@ -159,7 +159,7 @@ process SUMMARY_MARKERSHEET_LITERAL {
     def args        = task.ext.args ?: ''
     def prefix      = task.ext.prefix ?: "${meta.id}"
 
-    header = [
+    def header = [
             "channel_number",
             "cycle_number",
             "excitation_wavelength",
@@ -172,7 +172,7 @@ process SUMMARY_MARKERSHEET_LITERAL {
             "remove",
             "exposure_time_unit"]
 
-    output = [header]
+    def output = [header]
 
     markersheet.collect { m -> output.add( header.collect{ h -> m[h] ?: "" } ) }
 
@@ -198,10 +198,10 @@ process SUMMARY_SAMPLESHEET {
     def args        = task.ext.args ?: ''
     def prefix      = task.ext.prefix ?: "${meta.id}_${meta.cycle_number}"
 
-    check              = '\u2705'
-    cross              = '\u274C'
-    output_samplesheet = [["row_id", "variable_name", "value", "expected", "check"]]
-    counter            = 0
+    def check              = '\u2705'
+    def cross              = '\u274C'
+    def output_samplesheet = [["row_id", "variable_name", "value", "expected", "check"]]
+    def counter            = 0
 
     meta
         .each {
@@ -261,10 +261,10 @@ process SUMMARY_MARKERSHEET {
     def args        = task.ext.args ?: ''
     def prefix      = task.ext.prefix ?: "${meta.id}"
 
-    check              = '\u2705'
-    cross              = '\u274C'
-    output_markersheet = [["row_id", "variable_name", "value", "expected", "check"]]
-    counter = 0
+    def check              = '\u2705'
+    def cross              = '\u274C'
+    def output_markersheet = [["row_id", "variable_name", "value", "expected", "check"]]
+    def counter = 0
     markersheet
         .each { map ->
             map.each{ key, value ->


### PR DESCRIPTION
These modules' scripts didn't use "def" to define local variables as local so they were all part of the context and thus included in the task snapshot for nextflow task caching unnecessarily. This is mostly harmless but wasteful, however it did prevent some tasks from being usable with -resume since they have some local variables that Kryo serialization can't handle.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
