### PR TITLE
Add local mccellpose module as the default segmenter

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -68,6 +68,15 @@ process {
         ]
     }
 
+    withName: "MCCELLPOSE" {
+        ext.when = {params.segmentation && params.segmentation.split(',').contains('mccellpose')}
+        publishDir = [
+            path: { "${params.outdir}/segmentation/mccellpose" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: MCQUANT {
         publishDir = [
             path: { "${params.outdir}/quantification/mcquant/${meta2.segmenter}" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -21,8 +21,9 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [TMA Core Separation](#tma-core-separation)
   - [Coreograph](#coreograph)
 - [Segmentation](#segmentation)
-  - [Mesmer](#mesmer)
+  - [Mccellpose](#mccellpose)
   - [Cellpose](#cellpose)
+  - [Mesmer](#mesmer)
 - [Quantification](#quantification)
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
@@ -123,6 +124,17 @@ We generate a MultiQC formatted report with the extracted OME-xml data and the m
 </details>
 
 ### Segmentation
+
+#### Mccellpose
+
+[Mccellpose] A RAM-efficient wrapper around Cellpose (see below).
+
+<details>
+<summary>Output files</summary>
+
+- {sample_name}_mask_cell.ome.tif : labelled mask output from cellpose in OME-TIFF format
+
+</details>
 
 #### Cellpose
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -132,7 +132,7 @@ We generate a MultiQC formatted report with the extracted OME-xml data and the m
 <details>
 <summary>Output files</summary>
 
-- {sample_name}_mask_cell.ome.tif : labelled mask output from cellpose in OME-TIFF format
+- {sample_name}\_mask_cell.ome.tif : labelled mask output from cellpose in OME-TIFF format
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,7 +165,7 @@ This is an optional step that occurs immediately following background subtration
 
 #### Segmentation
 
-This is a required step that follows the TMA Core Separation step. The workflow will run the deepcell_mesmer module by default, but other options are available by using the `--segmentation` flag. The flag should be followed by a single segmentation module name or a comma separated list of names to run multiple segmentation modules in parallel. The available options currently supported are `mesmer` and `cellpose`. More information about each of these modules can be found on their respective nf-core module websites: [deepcell_mesmer](https://nf-co.re/modules/deepcell_mesmer/) [cellpose](https://nf-co.re/modules/cellpose/)
+This is a required step that follows the TMA Core Separation step. The workflow will run the mccellpose module by default, but other options are available by using the `--segmentation` flag. The flag should be followed by a single segmentation module name or a comma separated list of names to run multiple segmentation modules in parallel. The available options currently supported are `mccellpose`, `cellpose`, and `mesmer`. More information about each of these modules can be found on their respective nf-core module websites: [cellpose](https://nf-co.re/modules/cellpose/) [deepcell_mesmer](https://nf-co.re/modules/deepcell_mesmer/). (mccellpose is an alternative interface to cellpose that uses much less RAM and should be preferred in most cases)
 
 When `cellpose` is selected as a segmentation method you may also provide a pretrained model to the cellpose module by using the `--cellpose_model` flag followed by a full path or URL to the model file.
 

--- a/modules/local/mccellpose/main.nf
+++ b/modules/local/mccellpose/main.nf
@@ -1,0 +1,52 @@
+process MCCELLPOSE {
+    tag "$meta.id"
+    label 'process_low'
+    label 'process_gpu'
+
+    container "docker.io/labsyspharm/mccellpose:1.0.1"
+
+    input:
+    tuple val(meta), path(image)
+
+    output:
+    tuple val(meta), path("*_mask_*.ome.tif"), emit: mask
+    path "versions.yml"                      , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: '--channel 1'
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def gpu_args = task.ext.use_gpu ? "--use-gpu --jobs ${task.cpus}" : ''
+    """
+    export HOME=\$PWD
+    export NUMBA_CACHE_DIR=\$PWD
+
+    mccellpose \
+        --input $image \
+        --output-cell ${prefix}_mask_cell.ome.tif \
+        --channel 1 \
+        --expand-size 2 \
+        $gpu_args \
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mccellpose: \$(mccellpose --version | awk '{print \$2}')
+        cellpose: \$(cellpose --version | awk 'NR==2 {print \$3}')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_mask_cell.ome.tif
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mccellpose: \$(mccellpose --version | awk '{print \$2}')
+        cellpose: \$(cellpose --version | awk 'NR==2 {print \$3}')
+    END_VERSIONS
+    """
+}

--- a/modules/local/mccellpose/main.nf
+++ b/modules/local/mccellpose/main.nf
@@ -3,7 +3,7 @@ process MCCELLPOSE {
     label 'process_low'
     label 'process_gpu'
 
-    container "docker.io/labsyspharm/mccellpose:1.0.1"
+    container "docker.io/labsyspharm/mccellpose:1.0.2"
 
     input:
     tuple val(meta), path(image)

--- a/modules/local/mccellpose/meta.yml
+++ b/modules/local/mccellpose/meta.yml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "mccellpose"
+description: segments cells in images (mcmicro wrapper)
+keywords:
+  - segmentation
+  - image
+tools:
+  - "mccellpose":
+      description: "Alternative interface to the Cellpose cell segmentation algorithm that uses constant memory"
+      homepage: "https://github.com/labsyspharm/mccellpose"
+      documentation: "https://github.com/labsyspharm/mccellpose?tab=readme-ov-file#readme"
+      tool_dev_url: "https://github.com/labsyspharm/mccellpose"
+      doi: 10.1038/s41592-022-01663-4
+      licence: ["BSD 3-Clause"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - image:
+      type: file
+      description: TIFF image of cells to segment
+      pattern: "*.{tif,tiff}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - mask:
+      type: file
+      description: TIFF label mask with segmented cells
+      pattern: "*.{tif, tiff}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@jmuhlich"
+maintainers:
+  - "@jmuhlich"

--- a/modules/local/mccellpose/tests/main.nf.test
+++ b/modules/local/mccellpose/tests/main.nf.test
@@ -1,0 +1,62 @@
+nextflow_process {
+
+    name "Test Process MCCELLPOSE"
+    script "../main.nf"
+    process "MCCELLPOSE"
+
+    tag "modules"
+    tag "modules_local"
+    tag "mccellpose"
+
+    test("mccellpose defaults") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'imaging/segmentation/cycif_tonsil_registered.ome.tif', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.mask[0][0],
+                    file(process.out.mask[0][1]).name,
+                    file(process.out.mask[0][1]).length() > 90_000,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("mccellpose defaults - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'imaging/segmentation/cycif_tonsil_registered.ome.tif', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/local/mccellpose/tests/main.nf.test
+++ b/modules/local/mccellpose/tests/main.nf.test
@@ -26,6 +26,10 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.mask[0][0],
+                    // The tool is slightly unstable with respect to how many cells it detects on
+                    // the same image with repeated runs, so we can't snapshot the actual mask file
+                    // content. Instead we snapshot the filename and whether the file is big enough
+                    // to be sure it detected an acceptable number of cells.
                     file(process.out.mask[0][1]).name,
                     file(process.out.mask[0][1]).length() > 90_000,
                     process.out.versions

--- a/modules/local/mccellpose/tests/main.nf.test.snap
+++ b/modules/local/mccellpose/tests/main.nf.test.snap
@@ -7,14 +7,14 @@
             "test_mask_cell.ome.tif",
             true,
             [
-                "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+                "versions.yml:md5,eb9216687202137e6cc716621b335a15"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-13T17:47:13.18424089"
+        "timestamp": "2025-10-15T01:14:13.744937505"
     },
     "mccellpose defaults - stub": {
         "content": [
@@ -28,7 +28,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+                    "versions.yml:md5,eb9216687202137e6cc716621b335a15"
                 ],
                 "mask": [
                     [
@@ -39,7 +39,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+                    "versions.yml:md5,eb9216687202137e6cc716621b335a15"
                 ]
             }
         ],
@@ -47,6 +47,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-13T17:47:21.72366162"
+        "timestamp": "2025-10-15T01:14:42.372202235"
     }
 }

--- a/modules/local/mccellpose/tests/main.nf.test.snap
+++ b/modules/local/mccellpose/tests/main.nf.test.snap
@@ -1,0 +1,52 @@
+{
+    "mccellpose defaults": {
+        "content": [
+            {
+                "id": "test"
+            },
+            "test_mask_cell.ome.tif",
+            true,
+            [
+                "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-13T17:47:13.18424089"
+    },
+    "mccellpose defaults - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_mask_cell.ome.tif:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+                ],
+                "mask": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_mask_cell.ome.tif:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,2b745936fe50d82f5eaba93f25934abe"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-13T17:47:21.72366162"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     input_cycle                = null
     marker_sheet               = null
     tma_dearray                = false
-    segmentation               = 'mesmer'
+    segmentation               = 'mccellpose'
     cellpose_model             = []
 
     // prelude

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -72,8 +72,8 @@
                 },
                 "segmentation": {
                     "type": "string",
-                    "pattern": "^((cellpose|mesmer)?,?)*(?<!,)$",
-                    "description": "comma separated list of segmentation modules to run. options are ['mesmer','cellpose']"
+                    "pattern": "^((mccellpose|cellpose|mesmer)?,?)*(?<!,)$",
+                    "description": "comma separated list of segmentation modules to run. options are ['mccellpose','cellpose','mesmer']"
                 },
                 "cellpose_model": {
                     "type": "string",

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -19,7 +19,8 @@ nextflow_pipeline {
             def stable_path = getAllFilesFromDir(
                 params.outdir,
                 ignore: [
-                    'quantification/mcquant/mesmer/TEST1_mask_TEST1.csv',
+                    'quantification/mcquant/mccellpose/TEST1_TEST1_mask_cell.csv',
+                    'segmentation/mccellpose/TEST1_mask_cell.ome.tif',
                 ],
                 ignoreFile: 'tests/.nftignore',
             )

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -9,8 +9,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "mccellpose 1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -52,14 +53,14 @@
                 "pipeline_info/nf_core_mcmicro_software_mqc_versions.yml",
                 "quantification",
                 "quantification/mcquant",
-                "quantification/mcquant/mesmer",
-                "quantification/mcquant/mesmer/TEST1_mask_TEST1.csv",
+                "quantification/mcquant/mccellpose",
+                "quantification/mcquant/mccellpose/TEST1_TEST1_mask_cell.csv",
                 "registration",
                 "registration/ashlar",
                 "registration/ashlar/TEST1.ome.tif",
                 "segmentation",
-                "segmentation/deepcell_mesmer",
-                "segmentation/deepcell_mesmer/mask_TEST1.tif",
+                "segmentation/mccellpose",
+                "segmentation/mccellpose/TEST1_mask_cell.ome.tif",
                 "summary",
                 "summary/TEST1_1_samplesheet_mqc.tsv",
                 "summary/TEST1_1_xml_mqc.tsv",
@@ -72,7 +73,6 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_markers_markersheet.txt:md5,4cefab2c3058207af86e69d85c3f1e6d",
                 "TEST1.ome.tif:md5,988bbb2c74d47dc22a9f3ac348f53ef5",
-                "mask_TEST1.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
                 "TEST1_1_samplesheet_mqc.tsv:md5,13cf3b7ed83cfeae01242043c5b176b9",
                 "TEST1_1_xml_mqc.tsv:md5,bf43fc3bbc6b281cb1ac62e84febd8f4",
                 "markers_markersheet_mqc.tsv:md5,b302d9e7ce2a4bab3586f38d6753e368"
@@ -82,6 +82,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-26T16:05:38.764566284"
+        "timestamp": "2025-10-10T13:54:03.977061423"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -10,7 +10,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "mccellpose 1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -82,6 +82,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-10T13:54:03.977061423"
+        "timestamp": "2025-10-16T10:47:18.144996282"
     }
 }

--- a/tests/lib/CsvUtils.groovy
+++ b/tests/lib/CsvUtils.groovy
@@ -40,6 +40,19 @@ static Map summarizeCsv(String path) {
     ]
 }
 
+// Map.collectEntries helper for use with summarizeCsv when rowCount is unstable
+// but still within a consistent range.
+static Closure checkRowCount(int min, int max) {
+    return {
+        k, v -> {
+            if (k == 'rowCount') {
+                v = v >= min & v <= max ? "Is between ${min} and ${max}" : "Outside given range"
+            }
+            [k, v]
+        }
+    }
+}
+
 // Parse and round floating point values to the specified number of decimal
 // digits of precision. Pass other strings through untouched.
 static String roundIfDouble(String value, int precision) {

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -11,7 +11,7 @@ nextflow_workflow {
             when {
                 params {
                     outdir = "$outputDir"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -40,8 +40,9 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/TEST1.ome.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_TEST1.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/TEST1_mask_TEST1.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/TEST1_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/TEST1_TEST1_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },
@@ -57,7 +58,7 @@ nextflow_workflow {
                 params {
                     outdir = "$outputDir"
                     illumination = "basicpy"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -86,8 +87,9 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             ImageUtils.getImageMetadata("$outputDir/registration/ashlar/TEST1.ome.tif"),
-                            ImageUtils.getImageMetadata("$outputDir/segmentation/deepcell_mesmer/mask_TEST1.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/TEST1_mask_TEST1.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/TEST1_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/TEST1_TEST1_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-dfp.tiff"),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-ffp.tiff"),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
@@ -104,7 +106,7 @@ nextflow_workflow {
                 params {
                     outdir = "$outputDir"
                     illumination = "manual"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -133,8 +135,9 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/TEST1.ome.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_TEST1.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/TEST1_mask_TEST1.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/TEST1_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/TEST1_TEST1_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },
@@ -148,7 +151,7 @@ nextflow_workflow {
             when {
                 params {
                     outdir = "$outputDir"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -197,8 +200,9 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/cycif-tonsil.ome.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil_mask_cycif-tonsil.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },
@@ -212,7 +216,7 @@ nextflow_workflow {
             when {
                 params {
                     outdir = "$outputDir"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -264,10 +268,12 @@ nextflow_workflow {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/cycif-tonsil.ome.tif"),
                             path("$outputDir/registration/ashlar/cycif-tonsil2.ome.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil2.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil_mask_cycif-tonsil.csv"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil2_mask_cycif-tonsil2.csv"),
+                            path("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            path("$outputDir/segmentation/mccellpose/cycif-tonsil2_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil2_cycif-tonsil2_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -268,8 +268,8 @@ nextflow_workflow {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/cycif-tonsil.ome.tif"),
                             path("$outputDir/registration/ashlar/cycif-tonsil2.ome.tif"),
-                            path("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
-                            path("$outputDir/segmentation/mccellpose/cycif-tonsil2_mask_cell.ome.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil2_mask_cell.ome.tif"),
                             CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
                                 .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil2_cycif-tonsil2_mask_cell.csv")
@@ -287,7 +287,7 @@ nextflow_workflow {
             when {
                 params {
                     outdir = "$outputDir"
-                    segmentation = "mesmer,cellpose"
+                    segmentation = "mccellpose,cellpose,mesmer"
                 }
                 workflow {
                     """
@@ -343,10 +343,16 @@ nextflow_workflow {
                             path("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil2.tif"),
                             path("$outputDir/segmentation/cellpose/cycif-tonsil.ome_cp_masks.tif"),
                             path("$outputDir/segmentation/cellpose/cycif-tonsil2.ome_cp_masks.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil2_mask_cell.ome.tif"),
                             CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil_mask_cycif-tonsil.csv"),
                             CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil2_mask_cycif-tonsil2.csv"),
                             CsvUtils.roundAndHashCsv("$outputDir/quantification/mcquant/cellpose/cycif-tonsil_cycif-tonsil.csv"),
                             CsvUtils.roundAndHashCsv("$outputDir/quantification/mcquant/cellpose/cycif-tonsil2_cycif-tonsil2.csv"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil2_cycif-tonsil2_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },
@@ -361,7 +367,7 @@ nextflow_workflow {
                 params {
                     outdir = "$outputDir"
                     illumination = "basicpy"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -410,8 +416,9 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             ImageUtils.getImageMetadata("$outputDir/registration/ashlar/cycif-tonsil.ome.tif"),
-                            ImageUtils.getImageMetadata("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil_mask_cycif-tonsil.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-dfp.tiff"),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-ffp.tiff"),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle2.ome-dfp.tiff"),
@@ -432,7 +439,7 @@ nextflow_workflow {
                 params {
                     outdir = "$outputDir"
                     illumination = "basicpy"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                 }
                 workflow {
                     """
@@ -484,10 +491,12 @@ nextflow_workflow {
                         assert snapshot (
                             ImageUtils.getImageMetadata("$outputDir/registration/ashlar/cycif-tonsil.ome.tif"),
                             ImageUtils.getImageMetadata("$outputDir/registration/ashlar/cycif-tonsil2.ome.tif"),
-                            ImageUtils.getImageMetadata("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil.tif"),
-                            ImageUtils.getImageMetadata("$outputDir/segmentation/deepcell_mesmer/mask_cycif-tonsil2.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil_mask_cycif-tonsil.csv"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/cycif-tonsil2_mask_cycif-tonsil2.csv"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil_mask_cell.ome.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/cycif-tonsil2_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil_cycif-tonsil_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/cycif-tonsil2_cycif-tonsil2_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-dfp.tiff"),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle1.ome-ffp.tiff"),
                             ImageUtils.getImageMetadata("$outputDir/illumination_correction/basicpy/cycif-tonsil-cycle2.ome-dfp.tiff"),
@@ -595,7 +604,7 @@ nextflow_workflow {
             when {
                 params {
                     outdir = "$outputDir"
-                    segmentation = "mesmer"
+                    segmentation = "mccellpose"
                     backsub = true
                 }
                 workflow {
@@ -635,9 +644,10 @@ nextflow_workflow {
                     {
                         assert snapshot (
                             path("$outputDir/registration/ashlar/TEST1.ome.tif"),
-                            path("$outputDir/segmentation/deepcell_mesmer/mask_TEST1.tif"),
-                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mesmer/TEST1_backsub_mask_TEST1.csv"),
                             ImageUtils.getImageMetadata("$outputDir/backsub/TEST1_backsub.ome.tif"),
+                            ImageUtils.getImageMetadata("$outputDir/segmentation/mccellpose/TEST1_mask_cell.ome.tif"),
+                            CsvUtils.summarizeCsv("$outputDir/quantification/mcquant/mccellpose/TEST1_backsub_TEST1_mask_cell.csv")
+                                .collectEntries(CsvUtils.checkRowCount(2100, 2150)),
                             removeNextflowVersion("$outputDir/pipeline_info/nf_core_mcmicro_software_mqc_versions.yml"),
                         ).match()
                     },

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -166,7 +166,30 @@
     "cycle: no illumination correction, backsub": {
         "content": [
             "TEST1.ome.tif:md5,fd414b610e189f3e805c8e99f4e78c09",
-            "mask_TEST1.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
+            {
+                "format": "OME-TIFF",
+                "type": "uint16",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 7,
+                "sizeT": 1,
+                "physicalSizeX": 0.65,
+                "physicalSizeY": 0.65,
+                "physicalSizeZ": null
+            },
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -187,19 +210,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
-            },
-            {
-                "format": "OME-TIFF",
-                "type": "uint16",
-                "sizeX": 591,
-                "sizeY": 470,
-                "sizeZ": 1,
-                "sizeC": 7,
-                "sizeT": 1,
-                "physicalSizeX": 0.65,
-                "physicalSizeY": 0.65,
-                "physicalSizeZ": null
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "ASHLAR": {
@@ -211,8 +222,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -226,7 +238,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-01T13:19:26.619256164"
+        "timestamp": "2025-10-14T23:49:13.157157657"
     },
     "cycle: multiple file ashlar input with multiple samples no correction, multiple segmentation": {
         "content": [
@@ -236,6 +248,30 @@
             "mask_cycif-tonsil2.tif:md5,0799cd6935febaeb9e17f8a4173fe89a",
             "cycif-tonsil.ome_cp_masks.tif:md5,d00841c96b28338f34748fa9af422f2b",
             "cycif-tonsil2.ome_cp_masks.tif:md5,c7570f17e8e05208cc3f507cb7c13615",
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 468,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -285,6 +321,52 @@
             "cycif-tonsil_cycif-tonsil.csv:rounded:md5,caf85194a268b27087f598a1ef432dec",
             "cycif-tonsil2_cycif-tonsil2.csv:rounded:md5,8872bfc032718d36835c26c82e30fbca",
             {
+                "headers": [
+                    "CellID",
+                    "DNA_6",
+                    "ELANE",
+                    "CD57",
+                    "CD45",
+                    "DNA_7",
+                    "ELANE7",
+                    "CD577",
+                    "CD457",
+                    "X_centroid",
+                    "Y_centroid",
+                    "Area",
+                    "MajorAxisLength",
+                    "MinorAxisLength",
+                    "Eccentricity",
+                    "Solidity",
+                    "Extent",
+                    "Orientation"
+                ],
+                "rowCount": "Is between 2100 and 2150"
+            },
+            {
+                "headers": [
+                    "CellID",
+                    "DNA_6",
+                    "ELANE",
+                    "CD57",
+                    "CD45",
+                    "DNA_7",
+                    "ELANE7",
+                    "CD577",
+                    "CD457",
+                    "X_centroid",
+                    "Y_centroid",
+                    "Area",
+                    "MajorAxisLength",
+                    "MinorAxisLength",
+                    "Eccentricity",
+                    "Solidity",
+                    "Extent",
+                    "Orientation"
+                ],
+                "rowCount": "Is between 2100 and 2150"
+            },
+            {
                 "ASHLAR": {
                     "ashlar": "1.18.0"
                 },
@@ -296,6 +378,10 @@
                 },
                 "DEEPCELL_MESMER": {
                     "deepcell_mesmer": "0.4.1"
+                },
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -309,7 +395,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-26T15:30:25.913390498"
+        "timestamp": "2025-10-14T23:23:04.182858186"
     },
     "cycle: no illumination correction, cellpose segmentation": {
         "content": [
@@ -414,15 +500,15 @@
                 "physicalSizeZ": null
             },
             {
-                "format": "Tagged Image File Format",
-                "type": "int32",
+                "format": "OME-TIFF",
+                "type": "uint32",
                 "sizeX": 591,
                 "sizeY": 470,
                 "sizeZ": 1,
                 "sizeC": 1,
                 "sizeT": 1,
-                "physicalSizeX": 1.0,
-                "physicalSizeY": 1.0,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
                 "physicalSizeZ": null
             },
             {
@@ -450,7 +536,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "format": "Tagged Image File Format",
@@ -534,8 +620,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -549,7 +636,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-26T13:31:34.579386269"
+        "timestamp": "2025-10-14T23:13:20.115975044"
     },
     "cycle: multiple file ashlar input with multiple samples and basicpy correction": {
         "content": [
@@ -578,27 +665,27 @@
                 "physicalSizeZ": null
             },
             {
-                "format": "Tagged Image File Format",
-                "type": "int32",
+                "format": "OME-TIFF",
+                "type": "uint32",
                 "sizeX": 591,
                 "sizeY": 470,
                 "sizeZ": 1,
                 "sizeC": 1,
                 "sizeT": 1,
-                "physicalSizeX": 1.0,
-                "physicalSizeY": 1.0,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
                 "physicalSizeZ": null
             },
             {
-                "format": "Tagged Image File Format",
-                "type": "int32",
+                "format": "OME-TIFF",
+                "type": "uint32",
                 "sizeX": 591,
                 "sizeY": 468,
                 "sizeZ": 1,
                 "sizeC": 1,
                 "sizeT": 1,
-                "physicalSizeX": 1.0,
-                "physicalSizeY": 1.0,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
                 "physicalSizeZ": null
             },
             {
@@ -622,7 +709,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "headers": [
@@ -645,7 +732,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2082
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "format": "Tagged Image File Format",
@@ -729,8 +816,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -744,7 +832,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-26T13:53:30.817863804"
+        "timestamp": "2025-10-14T23:25:33.574057628"
     },
     "cycle: manual illumination correction": {
         "content": [
@@ -809,8 +897,30 @@
         "content": [
             "cycif-tonsil.ome.tif:md5,fd414b610e189f3e805c8e99f4e78c09",
             "cycif-tonsil2.ome.tif:md5,8615100afdf8e3e24174a6d82ecaea2c",
-            "cycif-tonsil_mask_cell.ome.tif:md5,594d34dbb43e5e4c68a59840938eff67",
-            "cycif-tonsil2_mask_cell.ome.tif:md5,3527b457e024d66e77c68ba9f45eacae",
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 468,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -880,7 +990,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T17:03:10.994560012"
+        "timestamp": "2025-10-14T23:19:57.226677005"
     },
     "cycle: no illumination correction, coreograph": {
         "content": [

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -2,7 +2,18 @@
     "cycle: multiple file ashlar input no correction": {
         "content": [
             "cycif-tonsil.ome.tif:md5,c01dda923325588ea34a4fe341b17e6e",
-            "mask_cycif-tonsil.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -28,7 +39,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "ASHLAR": {
@@ -37,8 +48,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -50,9 +62,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.1"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-07-18T11:51:19.289891764"
+        "timestamp": "2025-10-14T17:02:37.038139765"
     },
     "cycle: basicpy illumination correction": {
         "content": [
@@ -69,15 +81,15 @@
                 "physicalSizeZ": null
             },
             {
-                "format": "Tagged Image File Format",
-                "type": "int32",
+                "format": "OME-TIFF",
+                "type": "uint32",
                 "sizeX": 591,
                 "sizeY": 470,
                 "sizeZ": 1,
                 "sizeC": 1,
                 "sizeT": 1,
-                "physicalSizeX": 1.0,
-                "physicalSizeY": 1.0,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
                 "physicalSizeZ": null
             },
             {
@@ -97,7 +109,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "format": "Tagged Image File Format",
@@ -133,8 +145,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -148,7 +161,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-26T13:23:53.632560789"
+        "timestamp": "2025-10-14T17:01:34.479559377"
     },
     "cycle: no illumination correction, backsub": {
         "content": [
@@ -330,7 +343,18 @@
     "cycle: no illumination correction": {
         "content": [
             "TEST1.ome.tif:md5,988bbb2c74d47dc22a9f3ac348f53ef5",
-            "mask_TEST1.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -348,7 +372,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "ASHLAR": {
@@ -357,8 +381,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -370,9 +395,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.1"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-07-18T11:44:07.880608456"
+        "timestamp": "2025-10-14T16:59:43.540145553"
     },
     "cycle: multiple file ashlar input with basicpy correction": {
         "content": [
@@ -724,7 +749,18 @@
     "cycle: manual illumination correction": {
         "content": [
             "TEST1.ome.tif:md5,988bbb2c74d47dc22a9f3ac348f53ef5",
-            "mask_TEST1.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
+            {
+                "format": "OME-TIFF",
+                "type": "uint32",
+                "sizeX": 591,
+                "sizeY": 470,
+                "sizeZ": 1,
+                "sizeC": 1,
+                "sizeT": 1,
+                "physicalSizeX": null,
+                "physicalSizeY": null,
+                "physicalSizeZ": null
+            },
             {
                 "headers": [
                     "CellID",
@@ -742,7 +778,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "ASHLAR": {
@@ -751,8 +787,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -764,16 +801,16 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.1"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-07-18T11:50:53.104718819"
+        "timestamp": "2025-10-14T17:02:05.012435072"
     },
     "cycle: multiple file ashlar input with multiple samples no correction": {
         "content": [
             "cycif-tonsil.ome.tif:md5,fd414b610e189f3e805c8e99f4e78c09",
             "cycif-tonsil2.ome.tif:md5,8615100afdf8e3e24174a6d82ecaea2c",
-            "mask_cycif-tonsil.tif:md5,3103759bd55b9deeb8c8a0dade798d9a",
-            "mask_cycif-tonsil2.tif:md5,0799cd6935febaeb9e17f8a4173fe89a",
+            "cycif-tonsil_mask_cell.ome.tif:md5,594d34dbb43e5e4c68a59840938eff67",
+            "cycif-tonsil2_mask_cell.ome.tif:md5,3527b457e024d66e77c68ba9f45eacae",
             {
                 "headers": [
                     "CellID",
@@ -795,7 +832,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2111
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "headers": [
@@ -818,7 +855,7 @@
                     "Extent",
                     "Orientation"
                 ],
-                "rowCount": 2082
+                "rowCount": "Is between 2100 and 2150"
             },
             {
                 "ASHLAR": {
@@ -827,8 +864,9 @@
                 "BFTOOLS_SHOWINF": {
                     "showinf": "8.0.0"
                 },
-                "DEEPCELL_MESMER": {
-                    "deepcell_mesmer": "0.4.1"
+                "MCCELLPOSE": {
+                    "mccellpose": "1.0.1",
+                    "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
                     "mcquant": "1.5.4"
@@ -840,9 +878,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.1"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-07-18T11:51:46.523578952"
+        "timestamp": "2025-10-14T17:03:10.994560012"
     },
     "cycle: no illumination correction, coreograph": {
         "content": [

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -49,7 +49,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -64,7 +64,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T17:02:37.038139765"
+        "timestamp": "2025-10-15T01:17:17.396382874"
     },
     "cycle: basicpy illumination correction": {
         "content": [
@@ -146,7 +146,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -161,7 +161,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T17:01:34.479559377"
+        "timestamp": "2025-10-15T01:16:20.4417026"
     },
     "cycle: no illumination correction, backsub": {
         "content": [
@@ -223,7 +223,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -238,7 +238,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T23:49:13.157157657"
+        "timestamp": "2025-10-15T01:22:54.232562598"
     },
     "cycle: multiple file ashlar input with multiple samples no correction, multiple segmentation": {
         "content": [
@@ -380,7 +380,7 @@
                     "deepcell_mesmer": "0.4.1"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -395,7 +395,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T23:23:04.182858186"
+        "timestamp": "2025-10-15T01:18:22.300492348"
     },
     "cycle: no illumination correction, cellpose segmentation": {
         "content": [
@@ -468,7 +468,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -483,7 +483,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T16:59:43.540145553"
+        "timestamp": "2025-10-15T01:15:09.871327036"
     },
     "cycle: multiple file ashlar input with basicpy correction": {
         "content": [
@@ -621,7 +621,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -636,7 +636,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T23:13:20.115975044"
+        "timestamp": "2025-10-15T01:19:33.883130201"
     },
     "cycle: multiple file ashlar input with multiple samples and basicpy correction": {
         "content": [
@@ -817,7 +817,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -832,7 +832,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T23:25:33.574057628"
+        "timestamp": "2025-10-15T01:20:48.371580436"
     },
     "cycle: manual illumination correction": {
         "content": [
@@ -876,7 +876,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -891,7 +891,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T17:02:05.012435072"
+        "timestamp": "2025-10-15T01:16:48.13831678"
     },
     "cycle: multiple file ashlar input with multiple samples no correction": {
         "content": [
@@ -975,7 +975,7 @@
                     "showinf": "8.0.0"
                 },
                 "MCCELLPOSE": {
-                    "mccellpose": "1.0.1",
+                    "mccellpose": "1.0.2",
                     "cellpose": "4.0.7"
                 },
                 "MCQUANT": {
@@ -990,7 +990,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-14T23:19:57.226677005"
+        "timestamp": "2025-10-15T01:17:48.542025564"
     },
     "cycle: no illumination correction, coreograph": {
         "content": [

--- a/tests/workflows/mcmicro.nf.test
+++ b/tests/workflows/mcmicro.nf.test
@@ -9,7 +9,7 @@ nextflow_workflow {
         when {
             params {
                 outdir = "$outputDir"
-                segmentation = "mesmer"
+                segmentation = "mccellpose"
             }
             workflow {
                 """
@@ -47,7 +47,7 @@ nextflow_workflow {
         when {
             params {
                 outdir = "$outputDir"
-                segmentation = "mesmer"
+                segmentation = "mccellpose"
                 prelude = true
             }
             workflow {

--- a/tests/workflows/mcmicro.nf.test.snap
+++ b/tests/workflows/mcmicro.nf.test.snap
@@ -2,7 +2,7 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,038a3138460501f8cf5dcd982b1f05aa",
+                "versions.yml:md5,4ee6d9d92e380e33ed42e21fe6415427",
                 "versions.yml:md5,a95fffe435a8977d85664177b448b52c",
                 "versions.yml:md5,aff4555fe3c06d4ab2c2f58cf2cf9b18",
                 "versions.yml:md5,b25dd7741700a85d5421d11318fb0e99"
@@ -12,6 +12,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-19T15:22:58.333190406"
+        "timestamp": "2025-10-15T00:19:54.997791353"
     }
 }

--- a/tests/workflows/mcmicro.nf.test.snap
+++ b/tests/workflows/mcmicro.nf.test.snap
@@ -2,7 +2,7 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,4ee6d9d92e380e33ed42e21fe6415427",
+                "versions.yml:md5,6a0ec9f72aaa191caca00a5f1d1987ef",
                 "versions.yml:md5,a95fffe435a8977d85664177b448b52c",
                 "versions.yml:md5,aff4555fe3c06d4ab2c2f58cf2cf9b18",
                 "versions.yml:md5,b25dd7741700a85d5421d11318fb0e99"
@@ -12,6 +12,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-15T00:19:54.997791353"
+        "timestamp": "2025-10-15T01:23:21.325086316"
     }
 }

--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -16,6 +16,7 @@ include { BASICPY                } from '../modules/nf-core/basicpy/main'
 include { ASHLAR                 } from '../modules/nf-core/ashlar/main'
 include { BACKSUB                } from '../modules/nf-core/backsub/main'
 include { CELLPOSE               } from '../modules/nf-core/cellpose/main'
+include { MCCELLPOSE             } from '../modules/local/mccellpose/main'
 include { COREOGRAPH             } from '../modules/nf-core/coreograph/main'
 include { DEEPCELL_MESMER        } from '../modules/nf-core/deepcell/mesmer/main'
 include { SCIMAP_MCMICRO         } from '../modules/nf-core/scimap/mcmicro/main'
@@ -145,6 +146,14 @@ workflow MCMICRO {
             | CELLPOSE
         ch_masks = ch_masks.mix(CELLPOSE.out.mask)
         ch_versions = ch_versions.mix(CELLPOSE.out.versions)
+
+        ch_segmentation_input
+            .multiMap{ meta, image ->
+                image: [meta + [segmenter: 'mccellpose'], image]
+            }
+            | MCCELLPOSE
+        ch_masks = ch_masks.mix(MCCELLPOSE.out.mask)
+        ch_versions = ch_versions.mix(MCCELLPOSE.out.versions)
 
         // Run Quantification
 


### PR DESCRIPTION
mccellpose is a python script that feeds overlapping image tiles to the core cellpose segmentation model rather than reading the entire image at once as the official cellpose tool does. This reduces RAM usage dramatically and in fact makes usage more or less constant. Now images of virtually unlimited size can be segmented with cellpose without requiring hundreds of GB or more of RAM. We are shipping this as a local module within the pipeline for now while we get some experience with it and will ideally promote it to a global nf-core module or even integrate its features into cellpose itself. The original nf-core/cellpose module remains in the pipeline for users who wish to continue using it.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.