### PR TITLE
Update summary xml to include cycle number

### DIFF
--- a/modules/local/prelude/main.nf
+++ b/modules/local/prelude/main.nf
@@ -1,7 +1,7 @@
 import groovy.xml.XmlSlurper
 
 process SUMMARY_XML {
-    tag "$meta.id"
+    tag "${meta.id}_${meta.cycle_number}"
     label 'process_single'
 
     input:


### PR DESCRIPTION
Added cycle number to SUMMARY_XML tag so that it differenciates samples on progress and debug.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mcmicro _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
