### PR TITLE
Refractored code structure to support nextflow version 24.10.x

### DIFF
--- a/modules/local/prelude/main.nf
+++ b/modules/local/prelude/main.nf
@@ -8,7 +8,7 @@ process SUMMARY_XML {
     tuple val(meta), val(xml)
 
     output:
-    path output_file_xml, emit: output
+    path "*.tsv", emit: output
 
     when:
     task.ext.when == null || task.ext.when
@@ -137,9 +137,9 @@ process SUMMARY_XML {
         )
     }
 
-    output_file_xml = prefix + "_xml_mqc.tsv"
-    def f1          = task.workDir.resolve(output_file_xml)
-    f1.text         = output_xml*.join("\t").join("\n")
+    def output_file_xml = prefix + "_xml_mqc.tsv"
+    def f1              = task.workDir.resolve(output_file_xml)
+    f1.text             = output_xml*.join("\t").join("\n")
 }
 
 process SUMMARY_MARKERSHEET_LITERAL {
@@ -150,7 +150,7 @@ process SUMMARY_MARKERSHEET_LITERAL {
     tuple val(meta), val(markersheet)
 
     output:
-    path output_file_markersheet, emit: output
+    path "*.tsv", emit: output
 
     when:
     task.ext.when == null || task.ext.when
@@ -176,9 +176,9 @@ process SUMMARY_MARKERSHEET_LITERAL {
 
     markersheet.collect { m -> output.add( header.collect{ h -> m[h] ?: "" } ) }
 
-    output_file_markersheet = prefix + "_markersheet_mqc.tsv"
-    def f1                  = task.workDir.resolve(output_file_markersheet)
-    f1.text                 = output*.join("\t").join("\n")
+    def output_file_markersheet = prefix + "_markersheet_mqc.tsv"
+    def f1                      = task.workDir.resolve(output_file_markersheet)
+    f1.text                     = output*.join("\t").join("\n")
 }
 
 process SUMMARY_SAMPLESHEET {
@@ -189,7 +189,7 @@ process SUMMARY_SAMPLESHEET {
     tuple val(meta), val(samplesheet)
 
     output:
-    path output_file_samplesheet, emit: output
+    path "*.tsv", emit: output
 
     when:
     task.ext.when == null || task.ext.when
@@ -239,7 +239,7 @@ process SUMMARY_SAMPLESHEET {
             output_samplesheet.add(temp)
         }
 
-    output_file_samplesheet = prefix + "_samplesheet_mqc.tsv"
+    def output_file_samplesheet = prefix + "_samplesheet_mqc.tsv"
     def f1                  = task.workDir.resolve(output_file_samplesheet)
     f1.text                 = output_samplesheet*.join("\t").join("\n")
 }
@@ -252,7 +252,7 @@ process SUMMARY_MARKERSHEET {
     tuple val(meta), val(markersheet)
 
     output:
-    path output_file_markersheet, emit: output
+    path "*.tsv", emit: output
 
     when:
     task.ext.when == null || task.ext.when
@@ -309,7 +309,7 @@ process SUMMARY_MARKERSHEET {
             }
         }
 
-    output_file_markersheet = prefix + "_markersheet_mqc.tsv"
-    def f1                  = task.workDir.resolve(output_file_markersheet)
-    f1.text                 = output_markersheet*.join("\t").join("\n")
+    def output_file_markersheet = prefix + "_markersheet_mqc.tsv"
+    def f1                      = task.workDir.resolve(output_file_markersheet)
+    f1.text                     = output_markersheet*.join("\t").join("\n")
 }

--- a/subworkflows/local/prelude/main.nf
+++ b/subworkflows/local/prelude/main.nf
@@ -8,22 +8,22 @@ workflow PRELUDE {
     samplesheet
     xml
 
-    emit:
-    output_file_xml
-    output_file_samplesheet
-    output_file_markersheet
-
     main:
-    output_file_xml         = ( xml.map {
+    ch_output_xml         = ( xml.map {
                                     meta, xmlpath -> [meta, xmlpath]
                                     } | SUMMARY_XML ).output
 
-    output_file_markersheet = ( markersheet.map {
+    ch_output_markersheet = ( markersheet.map {
                                     [["id": "markers"], it]
                                     } | SUMMARY_MARKERSHEET_LITERAL ).output
 
-    output_file_samplesheet = ( samplesheet.map {
+    ch_output_samplesheet = ( samplesheet.map {
                                     meta, image_tiles, dfp, ffp ->
                                     [meta, [image_tiles, dfp, ffp]]
                                     } | SUMMARY_SAMPLESHEET).output
+
+    emit:
+    output_file_xml         = ch_output_xml
+    output_file_samplesheet = ch_output_samplesheet
+    output_file_markersheet = ch_output_markersheet
 }

--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -78,7 +78,7 @@ workflow MCMICRO {
                 [meta.subMap('id', 'pixel_size'), [meta.cycle_number, image_tiles, dfp, ffp]]
             }
             // FIXME: pass groupTuple size: from samplesheet cycle count
-            .groupTuple(sort: { a, b -> a[0] <=> b[0] })
+            .groupTuple(sort: { a, b -> a[0] <=> b[0] } )
             .map{ meta, cycles -> [meta, *cycles.collect{ it[1..-1] }.transpose()]}
             .dump(tag: 'ASHLAR in')
             // flatten() handles list of empty-lists, turning it into a single empty list.


### PR DESCRIPTION
This will be the first change regarding #122 to add nextflow version 24.10.x to MCMICRO

This PR addresses pipeline syntax that the new version is more relaxed and allowed but fails with 24.10.x 

We will not be adding a test suite for 24.10.x as multiple versions of nf-schema testing would be necessary.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).