### PR TITLE
Include cycle number in relevant process tags

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,6 +28,7 @@ process {
     }
 
     withName: BASICPY {
+        tag = { "${meta.id}_${meta.cycle_number}" }
         publishDir = [
             path: { "${params.outdir}/illumination_correction/basicpy" },
             mode: params.publish_dir_mode,
@@ -120,6 +121,7 @@ process {
     }
 
     withName: "BFTOOLS_SHOWINF" {
+        tag = { "${meta.id}_${meta.cycle_number}" }
         ext.prefix = { "${meta.id}_${meta.cycle_number}" }
         ext.args = "-option zeissczi.autostitch false -option zeissczi.attachments false"  //these options handle czi images
     }

--- a/modules/local/omevalidation/main.nf
+++ b/modules/local/omevalidation/main.nf
@@ -1,7 +1,7 @@
 import groovy.xml.XmlSlurper
 
 process OMEVALIDATION {
-    tag "$meta.id"
+    tag "${meta.id}_${meta.cycle_number}"
     label 'process_single'
 
     input:

--- a/modules/local/prelude/main.nf
+++ b/modules/local/prelude/main.nf
@@ -194,7 +194,7 @@ process SUMMARY_MARKERSHEET_LITERAL {
 }
 
 process SUMMARY_SAMPLESHEET {
-    tag "$meta.id"
+    tag "${meta.id}_${meta.cycle_number}"
     label 'process_single'
 
     input:


### PR DESCRIPTION
For processes that run on each imaging cycle, this appends the cycle number to the process tag to distinguish the tasks better in the nextflow status output and execution trace.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).