### PR TITLE
Use Nextflow file() and toUriString() for cloud storage compatibility

### DIFF
--- a/modules/local/omevalidation/main.nf
+++ b/modules/local/omevalidation/main.nf
@@ -5,13 +5,13 @@ process OMEVALIDATION {
     label 'process_single'
 
     input:
-    tuple val(meta), path(xmlPath)
+    tuple val(meta), val(xmlPath)
 
     output:
     tuple val(meta), val(sample_meta), val(marker_meta)
 
     exec:
-    def xml = new XmlSlurper().parse(new File(xmlPath.toString()))
+    def xml = new XmlSlurper().parseText(file(xmlPath.toString()).text)
 
     /*
     SAMPLESHEET DATA ----------------------------------------------------------------------------------------------

--- a/modules/local/omevalidation/main.nf
+++ b/modules/local/omevalidation/main.nf
@@ -11,7 +11,7 @@ process OMEVALIDATION {
     tuple val(meta), val(sample_meta), val(marker_meta)
 
     exec:
-    def xml = new XmlSlurper().parseText(file(xmlPath.toString()).text)
+    def xml = new XmlSlurper().parseText(file(xmlPath.toUriString()).text)
 
     /*
     SAMPLESHEET DATA ----------------------------------------------------------------------------------------------

--- a/modules/local/omevalidation/main.nf
+++ b/modules/local/omevalidation/main.nf
@@ -5,7 +5,7 @@ process OMEVALIDATION {
     label 'process_single'
 
     input:
-    tuple val(meta), val(xmlPath)
+    tuple val(meta), path(xmlPath)
 
     output:
     tuple val(meta), val(sample_meta), val(marker_meta)


### PR DESCRIPTION
 ~Changes xmlPath input from val() to path() so Nextflow stages the file locally before processing.~
Uses Nextflow's file() function instead of Java's File class, and replace toString() with toUriString() to read XML content. This fixes "No such file or directory" errors when running on cloud platforms (AWS S3, Azure, GCS) via Seqera Platform.  

Noted in review for PR #120 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mcmicro _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
