### PR TITLE
Update showinf args

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -124,7 +124,10 @@ process {
     withName: "BFTOOLS_SHOWINF" {
         tag = { "${meta.id}_${meta.cycle_number}" }
         ext.prefix = { "${meta.id}_${meta.cycle_number}" }
-        ext.args = "-option zeissczi.autostitch false -option zeissczi.attachments false"  //these options handle czi images
+        ext.args = { [
+            '-no-sas -novalid', // skip StructuredAnnotations and XML validation, for speed
+            '-option zeissczi.autostitch false -option zeissczi.attachments false', // handle czi images
+        ].join(' ').trim() }
     }
 
     /*

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -126,6 +126,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.cycle_number}" }
         ext.args = { [
             '-no-sas -novalid', // skip StructuredAnnotations and XML validation, for speed
+            '-noflat', // don't create explicit Image elements for pyramid subresolutions
             '-option zeissczi.autostitch false -option zeissczi.attachments false', // handle czi images
         ].join(' ').trim() }
     }


### PR DESCRIPTION
* Disable emitting extra annotations in the XML that we don't read. This reduces the XML file size and speeds up the process as well.
* Skip XML schema validation for generated XML, speeding up the process.
* Disable emitting Image elements in the XML for pyramid sublevels, which will be necessary for when we start accepting Level 2 stitched images as inputs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
