### PR TITLE
Fix up local workflows to make a pipeline stub run work

### DIFF
--- a/subworkflows/local/prelude/main.nf
+++ b/subworkflows/local/prelude/main.nf
@@ -9,6 +9,14 @@ workflow PRELUDE {
     xml
 
     main:
+
+    if (workflow.stubRun) {
+        output_file_xml         = Channel.of([])
+        output_file_samplesheet = Channel.of([])
+        output_file_markersheet = Channel.of([])
+        return
+    }
+
     ch_output_xml         = ( xml.map {
                                     meta, xmlpath -> [meta, xmlpath]
                                     } | SUMMARY_XML ).output

--- a/subworkflows/local/update_from_ome/main.nf
+++ b/subworkflows/local/update_from_ome/main.nf
@@ -7,6 +7,11 @@ workflow UPDATE_FROM_OME {
     xml
 
     main:
+
+    if (workflow.stubRun) {
+        return
+    }
+
     val_data = xml.map{meta, x -> [meta, x]} | OMEVALIDATION
 
     samplesheet.join(val_data)


### PR DESCRIPTION
Our local modules that use exec: blocks for error checking and other reporting will fail for stub runs, generally due to trying to parse nonexistent files. This change skips the affected subworkflows on stub runs. Since there are no relevant files to parse on a stub run, these steps can safely be skipped.

<!--
# nf-core/mcmicro pull request

Many thanks for contributing to nf-core/mcmicro!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mcmicro/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
