### PR TITLE
Fix nextflow inspect parse error in mcmicro.nf

### DIFF
--- a/workflows/mcmicro.nf
+++ b/workflows/mcmicro.nf
@@ -86,7 +86,7 @@ workflow MCMICRO {
         }
         // FIXME: pass groupTuple size: from samplesheet cycle count
         .groupTuple(sort: { a, b -> a[0] <=> b[0] } )
-        .map{ meta, cycles -> [meta, *cycles.collect{ it[1..-1] }.transpose()]}
+        .map{ meta, cycles -> [meta] + cycles.collect{ it[1..-1] }.transpose() }
         .dump(tag: 'ASHLAR in')
         // flatten() handles list of empty-lists, turning it into a single empty list.
         .multiMap{ meta, images, dfps, ffps ->


### PR DESCRIPTION
The `Test successful pipeline download` CI job (run on PR #120) fails due to the Nextflow parser rejecting the spread operator in [workflows/mcmicro.nf:89](workflows/mcmicro.nf#L89):

```
Error workflows/mcmicro.nf:89:38: Unexpected input: '*'
```

All the downstream `Module could not be parsed` / `is not defined` errors cascade from this single parse failure.

We replace the spread operator with list concatenation which produces an identical result
