### PR TITLE
Lower OMEVALIDATION memory to fit small runners

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -61,4 +61,12 @@ process {
         ext.use_gpu = { workflow.profile.contains('gpu') }
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
+
+    // OMEVALIDATION is a native `exec` process: it parses OME-XML in the
+    // Nextflow head-job JVM rather than submitting a task, so it needs only a
+    // trivial amount of memory. Override the process_single default (6 GB) so
+    // it does not exceed the available memory on small runners.
+    withName: '.*:OMEVALIDATION' {
+        memory = { 1.GB * task.attempt }
+    }
 }


### PR DESCRIPTION
## Problem

The full test fails with:

```
Process requirement exceeds available memory -- req: 6 GB; avail: 4 GB
```

on `NFCORE_MCMICRO:MCMICRO:UPDATE_FROM_OME:OMEVALIDATION`.

`OMEVALIDATION` is a native `exec` process operating in the Nextflow head-job JVM. However, by virtue of having `label 'process_single'` it inherited a 6 GB memory request. The local executor validates that request against the runner's actual RAM (4 GB) and aborts before the process runs. 

Adding a `withName: '.*:OMEVALIDATION'` selector in `conf/base.config` setting memory to 1 GB. `withName` is more specific than `withLabel:process_single`, so it overrides the 6 GB default everywhere while keeping the `process_single` label intact for nf-core lint.

