### PR TITLE
Run download test on pre-strict-syntax nextflow version

### DIFF
--- a/.github/workflows/download_pipeline.yml
+++ b/.github/workflows/download_pipeline.yml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
+        # FIXME remove this once we merge PR 153 so we are strict-syntax-compliant
+        with:
+          version: 25.10.5
 
       - name: Disk space cleanup
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION
We aren't quite ready for strict syntax, so we need to explicitly set the Nextflow version in the `pipelines download` workflow in addition to the obvious nf-test workflow.